### PR TITLE
Add more union schemas

### DIFF
--- a/src/Schemas.ts
+++ b/src/Schemas.ts
@@ -538,7 +538,7 @@ export function unionMany<
  * specified explicitly; otherwise the type will be incorrectly widened (e.g.
  * to `string` instead of `"foo" | "bar"`).
  */
-export function literalUnion<T>(...values: NonEmptyArray<T>): Schema<T, T> {
+export function literalUnionMany<T>(...values: NonEmptyArray<T>): Schema<T, T> {
     return foldMapNonEmpty(values, x => literal(x), (x, y) => union(x, y));
 }
 

--- a/src/Schemas.ts
+++ b/src/Schemas.ts
@@ -1,7 +1,7 @@
 // A set of data-oriented combinators for building up complex schemas
 
-import { Head, Tail, Snoc } from "./Tuples";
-import { Schema, InjectSchema, DomainOf, ReprOf } from "./Schema";
+import { Snoc } from "./Tuples";
+import { Schema, InjectSchema } from "./Schema";
 import { NonEmptyArray, id, impossible, foldMapNonEmpty } from "./Utils";
 
 /**
@@ -529,7 +529,7 @@ export function unionMany<
     R extends NonEmptyArray<Schema<any, any>>
 >(...elementSchemas: R): Schema<UnionDomainsReprs<R>, UnionDomainsReprs<R>> {
     return elementSchemas.reduce((prev, curr) => union(prev, curr));
-};
+}
 
 /**
  * Construct a schema for a union of literal values.
@@ -538,7 +538,7 @@ export function unionMany<
  * specified explicitly; otherwise the type will be incorrectly widened (e.g.
  * to `string` instead of `"foo" | "bar"`).
  */
- export function literalUnion<T>(...values: NonEmptyArray<T>): Schema<T, T> {
+export function literalUnion<T>(...values: NonEmptyArray<T>): Schema<T, T> {
     return foldMapNonEmpty(values, x => literal(x), (x, y) => union(x, y));
 }
 

--- a/src/Schemas.ts
+++ b/src/Schemas.ts
@@ -1,8 +1,8 @@
 // A set of data-oriented combinators for building up complex schemas
 
-import { Snoc } from "./Tuples";
-import { Schema, InjectSchema } from "./Schema";
-import { NonEmptyArray, id, impossible } from "./Utils";
+import { Head, Tail, Snoc } from "./Tuples";
+import { Schema, InjectSchema, DomainOf, ReprOf } from "./Schema";
+import { NonEmptyArray, id, impossible, foldMapNonEmpty } from "./Utils";
 
 /**
  * The possible types of the keys of an object
@@ -508,6 +508,36 @@ export function union<TL, TR, SR>(left: Schema<TL, TL>, right: Schema<TR, SR>): 
         left,
         right,
     );
+}
+
+type UnionDomainsReprs<Schemas extends unknown[], Acc = never> =
+    Schemas extends [infer H, ...(infer T)]
+        ? H extends Schema<infer D, infer D>
+            ? UnionDomainsReprs<T, Acc | D>
+            : never
+        : Acc;
+
+/**
+ * Construct a schema for a type union given any number of schemas. The schemas
+ * must be trivially encodable ('Schema<T, T>'). Like 'union' and 'unionOf',
+ * this is left-biased; the first (leftmost) schema will apply in the case
+ * where more than one schema would validate a value.
+ */
+export function multiUnion<
+    R extends NonEmptyArray<Schema<any, any>>
+>(...elementSchemas: R): Schema<UnionDomainsReprs<R>, UnionDomainsReprs<R>> {
+    return elementSchemas.reduce((prev, curr) => union(prev, curr));
+};
+
+/**
+ * Construct a schema for a union of literal values.
+ *
+ * The values should be declared with `as const` unless the type parameter is
+ * specified explicitly; otherwise the type will be incorrectly widened (e.g.
+ * to `string` instead of `"foo" | "bar"`).
+ */
+ export function literalUnion<T>(...values: NonEmptyArray<T>): Schema<T, T> {
+    return foldMapNonEmpty(values, x => literal(x), (x, y) => union(x, y));
 }
 
 /**

--- a/src/Schemas.ts
+++ b/src/Schemas.ts
@@ -522,8 +522,10 @@ type UnionDomainsReprs<Schemas extends unknown[], Acc = never> =
  * must be trivially encodable ('Schema<T, T>'). Like 'union' and 'unionOf',
  * this is left-biased; the first (leftmost) schema will apply in the case
  * where more than one schema would validate a value.
+ *
+ * See the note about `any`s in 'recordOf'.
  */
-export function multiUnion<
+export function unionMany<
     R extends NonEmptyArray<Schema<any, any>>
 >(...elementSchemas: R): Schema<UnionDomainsReprs<R>, UnionDomainsReprs<R>> {
     return elementSchemas.reduce((prev, curr) => union(prev, curr));

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,5 +1,9 @@
 export type NonEmptyArray<T> = [T, ...T[]];
 
+export function foldMapNonEmpty<T, R>(xs: NonEmptyArray<T>, f: (t: T) => R, g: (current: R, acc: R) => R) {
+    return xs.map(x => f(x)).reduce((x, y) => g(x, y));
+}
+
 /**
  * Function to use when the compiler needs a path to be present, even when it's
  * technically unreachable.

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,6 +1,6 @@
 export type NonEmptyArray<T> = [T, ...T[]];
 
-export function foldMapNonEmpty<T, R>(xs: NonEmptyArray<T>, f: (t: T) => R, g: (current: R, acc: R) => R) {
+export function foldMapNonEmpty<T, R>(xs: NonEmptyArray<T>, f: (t: T) => R, g: (current: R, acc: R) => R): R {
     return xs.map(x => f(x)).reduce((x, y) => g(x, y));
 }
 


### PR DESCRIPTION
Adds two new schemas for unions: `literalUnion` for creating a union of any number of literal values, and `multiUnion` for constructing a union from more than two trivial schemas (this previously required nesting the `union` function).

`multiUnion` is a bad placeholder name and I welcome suggestions about what that function should be called.